### PR TITLE
close #14, NODE_ENV=production gulp build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,9 @@ module.exports = {
     ],
   },
   plugins: [
-    new webpack.optimize.UglifyJsPlugin()
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': `"${process.env.NODE_ENV || 'development'}"`,
+    }),
+    new webpack.optimize.UglifyJsPlugin(),
   ]
 };


### PR DESCRIPTION
webpack.config.jsでwebpack.DefinePluginを使ってprocess.env.NODE_ENVを定義して。

``` sh
$ NODE_ENV=production gulp build
```

でプロダクション環境のビルドを可能にした。

参考：
http://stackoverflow.com/questions/30030031/passing-environment-dependent-variables-in-webpack
